### PR TITLE
Catch error when opening database

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 
+	_ "github.com/mattn/go-sqlite3"
 	"github.com/roberto-aldera/meal-planner/database"
 	"github.com/roberto-aldera/meal-planner/strategy"
 	"github.com/roberto-aldera/meal-planner/utilities"

--- a/main.go
+++ b/main.go
@@ -26,7 +26,11 @@ func main() {
 
 	// Load meals from database and print out all candidates
 	if config.MealDatabasePath != "" {
-		sqliteDatabase, _ := sql.Open("sqlite3", config.MealDatabasePath)
+		sqliteDatabase, err := sql.Open("sqlite3", config.MealDatabasePath)
+		if err != nil {
+			fmt.Printf("Failure in opening meal database: %s", err)
+		}
+		fmt.Printf("sqliteDatabase.Stats(): %v\n", sqliteDatabase.Stats())
 		defer sqliteDatabase.Close()
 		allMealsFromDatabase, err := database.LoadDatabaseEntriesIntoContainer(sqliteDatabase)
 		if err != nil {


### PR DESCRIPTION
The database was failing to open because of a missing import, and by failing to check `err` this was occurring quietly. We should check for the error, and then fix it too.